### PR TITLE
install ca-certs for cert failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ VOLUME /config
 ENV PUID=65532
 
 RUN apt-get update && apt-get install -y \
+        ca-certificates \
         jq \
         sudo \
     && rm -rf /var/lib/apt/lists


### PR DESCRIPTION

Fixes this:

```
cloudflared_1  | 2021-10-30T23:15:38Z ERR update check failed error="Get \"https://update.argotunnel.com?arch=amd64&clientVersion=2021.10.5&os=linux\": x509: certificate signed by unknown authority"
```
